### PR TITLE
core/web_browser: Allow WebApplet to exit gracefully when an error oc…

### DIFF
--- a/src/core/hle/service/am/applets/web_browser.cpp
+++ b/src/core/hle/service/am/applets/web_browser.cpp
@@ -254,6 +254,9 @@ void WebBrowser::Execute() {
 
     if (status != RESULT_SUCCESS) {
         complete = true;
+        Finalize();
+        // Set the status to RESULT_SUCCESS, so the application doesn't svcBreak when returning
+        status = RESULT_SUCCESS;
         return;
     }
 


### PR DESCRIPTION
…curs

Currently, yuzu just freezes when an error occurs while Initializing the WebApplet.
From a user perspective, this obviously isn't great as the game just softlocks.
With this change, yuzu will call the Finalize method, so to the game it seems like as the user just exited the WebApplet normally.

This works around https://github.com/yuzu-emu/yuzu/issues/2852.